### PR TITLE
Add dedication page with embedded video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,7 @@
-# Quantum Signal Oracle
+# Simple Dedication Page
 
-This lightweight website delivers random futuristic predictions with a retro-glitch aesthetic. Customize the text, styling or functionality and sell the template as a digital download on Etsy.
+This repository contains a single-page website designed as a short dedication. The page displays a personal message and embeds a YouTube video.
 
-## Features
+To view the page, open `index.html` in any modern browser. No build steps or external dependencies are required.
 
-- Responsive single-page layout
-- Glitch effect header
-- "Next Signal" button generates a new random prediction
-- "Copy" and "Share" buttons for quick interactions
-- Minimal CSS and vanilla JavaScript—easy to edit
-
-## Getting Started
-
-1. Clone or download this repository.
-2. Open `index.html` in your browser to preview.
-3. Edit `predictions` in `script.js` or tweak the styles in `styles.css` to match your brand.
-4. When ready, compress the project files into a ZIP archive and upload as a digital product on Etsy or deploy to any static hosting platform.
-
-## License
-
-This project is released into the public domain. Use it freely in commercial products, including resale.
+The project files are released into the public domain.

--- a/index.html
+++ b/index.html
@@ -3,22 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Mystical oracle generating random predictions. Perfect for digital product sales.">
-    <title>Quantum Signal Oracle</title>
+    <title>For You</title>
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <div class="container">
-        <h1 class="glitch" data-text="Quantum Signal Oracle">Quantum Signal Oracle</h1>
-        <p class="intro">Fragile transmissions from the next timeline. For entertainment only.</p>
-        <div id="prediction" class="prediction"></div>
-        <div class="buttons">
-            <button id="next">Next Signal</button>
-            <button id="copy">Copy</button>
-            <button id="share">Share</button>
-        </div>
+        <h1>For You</h1>
+        <p>This is for you. I spent a couple 💰’s to show I care about you. Money isn’t much to show how much I care, but it’s to show the problem isn’t the money or that I don’t take you seriously. I just really have to focus on my career.</p>
+        <iframe width="560" height="315" src="https://www.youtube.com/embed/RUGZaMCXdRQ?si=KYUJtT4jVMo0CEhG" title="YouTube video" frameborder="0" allowfullscreen></iframe>
     </div>
-    <footer>© 2024 Temporal Echo Labs</footer>
-    <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace previous sample site with a simple dedication page
- update project README

## Testing
- `ls -R | head`

------
https://chatgpt.com/codex/tasks/task_e_684985bdd090832d8f4eeb287a3d5da1